### PR TITLE
Update panel-sharp-ls054b3sx01.c for 60Hz refresh rate with no screen flashing or ghosting

### DIFF
--- a/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
+++ b/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
@@ -234,18 +234,18 @@ static int sharp_ls054_unprepare(struct drm_panel *panel)
 
 // FIXME: should we strive for perfect 60hz?
 static const struct drm_display_mode sharp_ls054_mode = {
-	.clock		= ((1152 + 64 + 4 + 32) * (1920 + 3 + 3 + 4) * 60) / 1000,
+	.clock		= ((1152 + 64 + 8 + 28) * (1920 + 56 + 3 + 6) * 60) / 1000,
 	.hdisplay	= 1152,
 	.hsync_start	= 1152 + 64,
-	.hsync_end	= 1152 + 64 + 4,
-	.htotal		= 1152 + 64 + 4 + 32,
+	.hsync_end	= 1152 + 64 + 8,
+	.htotal		= 1152 + 64 + 8 + 28,
 	.vdisplay	= 1920,
-	.vsync_start	= 1920 + 3,
-	.vsync_end	= 1920 + 3 + 3,
-	.vtotal		= 1920 + 3 + 3 + 4,
+	.vsync_start	= 1920 + 56,
+	.vsync_end	= 1920 + 56 + 3,
+	.vtotal		= 1920 + 56 + 3 + 6,
 	.width_mm	= 70,
 	.height_mm	= 117,
-//	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
+	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
 };
 
 static int sharp_ls054_get_modes(struct drm_panel *panel,

--- a/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
+++ b/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
@@ -245,7 +245,7 @@ static const struct drm_display_mode sharp_ls054_mode = {
 	.vtotal		= 1920 + 3 + 3 + 4,
 	.width_mm	= 70,
 	.height_mm	= 117,
-	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
+//	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
 };
 
 static int sharp_ls054_get_modes(struct drm_panel *panel,

--- a/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
+++ b/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
@@ -234,7 +234,7 @@ static int sharp_ls054_unprepare(struct drm_panel *panel)
 
 // FIXME: should we strive for perfect 60hz?
 static const struct drm_display_mode sharp_ls054_mode = {
-	.clock		= 150000,
+	.clock		= ((1152 + 64 + 4 + 32) * (1920 + 3 + 3 + 4) * 60) / 1000,
 	.hdisplay	= 1152,
 	.hsync_start	= 1152 + 64,
 	.hsync_end	= 1152 + 64 + 4,
@@ -243,8 +243,8 @@ static const struct drm_display_mode sharp_ls054_mode = {
 	.vsync_start	= 1920 + 3,
 	.vsync_end	= 1920 + 3 + 3,
 	.vtotal		= 1920 + 3 + 3 + 4,
-	.width_mm	= 69,
-	.height_mm	= 116,
+	.width_mm	= 70,
+	.height_mm	= 117,
 	.flags		= DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC,
 };
 

--- a/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
+++ b/drivers/gpu/drm/panel/panel-sharp-ls054b3sx01.c
@@ -234,11 +234,11 @@ static int sharp_ls054_unprepare(struct drm_panel *panel)
 
 // FIXME: should we strive for perfect 60hz?
 static const struct drm_display_mode sharp_ls054_mode = {
-	.clock		= ((1152 + 64 + 8 + 28) * (1920 + 56 + 3 + 6) * 60) / 1000,
+	.clock		= ((1152 + 64 + 4 + 32) * (1920 + 56 + 3 + 6) * 60) / 1000,
 	.hdisplay	= 1152,
 	.hsync_start	= 1152 + 64,
-	.hsync_end	= 1152 + 64 + 8,
-	.htotal		= 1152 + 64 + 8 + 28,
+	.hsync_end	= 1152 + 64 + 4,
+	.htotal		= 1152 + 64 + 4 + 32,
 	.vdisplay	= 1920,
 	.vsync_start	= 1920 + 56,
 	.vsync_end	= 1920 + 56 + 3,


### PR DESCRIPTION
sharp_ls054_mode with values matching https://github.com/SummerSunGenius/RG552_kernel/blob/master/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
Pixel clock for 60Hz refresh rate.
DRM_MODE_FLAG_NHSYNC and DRM_MODE_FLAG_NVSYNC flags set for no screen flashing or ghosting.